### PR TITLE
Add a command to generate a protocol buffer descriptor

### DIFF
--- a/build_protos.sh
+++ b/build_protos.sh
@@ -88,3 +88,15 @@ protoc ${INCLUDE} \
 mv -f .build/protos/github.com/jlewi/flaap/go/protos/ \
     go/
 
+
+# Generate API descriptor. This generates a protocol buffer that represents
+# the contents of our protocol buffers
+# See: https://cloud.google.com/endpoints/docs/grpc/configure-endpoints
+# https://developers.google.com/protocol-buffers/docs/techniques#self-description
+OUTFILE=.build/protos/api_descriptor.pb
+protoc ${INCLUDE} \
+    --include_imports \
+    --include_source_info \
+    --descriptor_set_out=${OUTFILE} \
+    ${SRCS} ${TFF_SRCS}
+


### PR DESCRIPTION
* This can be used to create API endpoints; e.g. https://cloud.google.com/endpoints/docs/grpc/configure-endpoints